### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+import os
+from setuptools import setup, find_packages
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+setup(
+    name='evernote',
+    version='1.22',
+    author='Evernote Corporation',
+    author_email='en-support@evernote.com',
+    url='http://dev.evernote.com',
+    description='Evernote SDK for Python',
+    long_description=read('README.md'),
+    packages=find_packages('lib'),
+    package_dir={'': 'lib'},
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Topic :: Software Development :: Libraries',
+    ],
+    license='BSD',
+)


### PR DESCRIPTION
I've created a setup script so that we can install the evernote python SDK in the standard python module way (http://docs.python.org/distutils/setupscript.html).

just run

```
python setup.py install
```

and the library will be installed in your PYTHONPATH.

This makes the library ready for PyPI, or installed directly from github (eg pip install git+git://github.com/evernote/evernote-sdk-python.git).
