### PR TITLE
Turn off debugging messages by default

### DIFF
--- a/lib/thrift/transport/THttpClient.py
+++ b/lib/thrift/transport/THttpClient.py
@@ -94,7 +94,7 @@ class THttpClient(TTransportBase):
     def open(self):
         protocol = httplib.HTTP if self.scheme == 'http' else httplib.HTTPS
         self.__http = protocol(self.endpoint_host, self.endpoint_port)
-        self.__http.set_debuglevel(1) #TODO
+        self.__http.set_debuglevel(0) #TODO
 
     def close(self):
         self.__http.close()


### PR DESCRIPTION
By default, the debugging messages in lib/thrift/transport/THttpClient.py were turned on...it should be turned off.
