### PR TITLE
Fix path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The code in `sample/client/EDAMTest.py` demonstrates the basics of using the Eve
 3. On the command line, run the following command to execute the script:
 
     ```bash
-    $ export PYTHONPATH=../lib; python EDAMTest.py
+    $ export PYTHONPATH=../../lib; python EDAMTest.py
     ```
 
 Getting Started - Django with OAuth


### PR DESCRIPTION
The example command for "Getting Started - Client" of the README file contains an incorrect path.
(cf. https://github.com/mrorii/evernote-sdk-python/blob/aa8557aa5b6fd8eb5c65da30a93a1e0817b285ca/sample/client/EDAMTest.py#L7-L8)
