### PR TITLE
Added __version__ = '1.25.0'

### DIFF
--- a/lib/evernote/api/client.py
+++ b/lib/evernote/api/client.py
@@ -13,6 +13,7 @@ import evernote.edam.userstore.constants as UserStoreConstants
 import thrift.protocol.TBinaryProtocol as TBinaryProtocol
 import thrift.transport.THttpClient as THttpClient
 
+__version__ = '1.25.0'
 
 class EvernoteClient(object):
 


### PR DESCRIPTION
Enable runtime verification of module version number.

``` python
import evernote
print(evernote.__version__)
```
