### PR TITLE
Exclude bundled thrift, install_requires it instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     description='Evernote SDK for Python',
     long_description=read('README.md'),
     packages=find_packages('lib'),
-    package_dir={'': 'lib'},
+    packages=find_packages('lib',exclude=["*.thrift", "*.thrift.*", "thrift.*", "thrift"]),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -28,6 +28,7 @@ setup(
     ],
     license='BSD',
     install_requires=[
+        'thrift',
         'oauth2',
     ],
 )


### PR DESCRIPTION
Correctly package evernote by excluding any bundled thrift modules from
installation and use install_requires to depend on the (PyPI) package
instead. This prevents package/installation conflicts between other
Python packages that depend on thrift.

This change has been included in the FreeBSD www/py-evernote port
since August 2014 [1]

Resolves #33 
[1] https://www.freshports.org/www/py-evernote/
