### PR TITLE
Fix setup.py duplicated keyword arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     description='Evernote SDK for Python',
     long_description=read('README.md'),
     packages=find_packages('lib', exclude=["*.thrift", "*.thrift.*", "thrift.*", "thrift"]),
+    package_dir={'': 'lib'},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setup(
     url='http://dev.evernote.com',
     description='Evernote SDK for Python',
     long_description=read('README.md'),
-    packages=find_packages('lib'),
-    packages=find_packages('lib',exclude=["*.thrift", "*.thrift.*", "thrift.*", "thrift"]),
+    packages=find_packages('lib', exclude=["*.thrift", "*.thrift.*", "thrift.*", "thrift"]),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This package was not installing because of the duplicated keyword arg in setup.py. I tried using #62 but got an error saying the package directory couldn't be found, so it seems like `package_dir` is still required. This version works.